### PR TITLE
Move autotype to devDependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
     },
     jasmine: {
       build: {
-        src : ['spec/js/libs/jquery/jquery.min.js', 'spec/js/libs/bootstrap/js/bootstrap.min.js', 'spec/js/libs/autotype/index.js', 'js/bootstrap-timepicker.js'],
+        src : ['spec/js/libs/jquery/dist/jquery.min.js', 'spec/js/libs/bootstrap/dist/js/bootstrap.min.js', 'spec/js/libs/autotype/index.js', 'js/bootstrap-timepicker.js'],
         options: {
           specs : 'spec/js/*Spec.js',
           helpers : 'spec/js/helpers/*.js',

--- a/component.json
+++ b/component.json
@@ -9,8 +9,9 @@
     "main": ["js/bootstrap-timepicker.min.js", "css/bootstrap-timepicker.min.css"],
     "dependencies": {
         "bootstrap": ">=3.0",
-        "jquery": ">=1.8.3",
+        "jquery": ">=1.8.3"
+    },
+    "devDependencies": {
         "autotype": "https://raw.github.com/mmonteleone/jquery.autotype/master/jquery.autotype.js"
     }
 }
-


### PR DESCRIPTION
The package `autotype` should be specified as `devDependencies` because it is used only by tests.

And also fixes some paths.